### PR TITLE
Add executable derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ nix build github:srid/devour-flake \
 
 Pipe this to `| xargs cat | cachix push <name>` to [push all flake outputs to cachix](https://github.com/juspay/jenkins-nix-ci/commit/71003fbaaba8a17e02bc74c70504ebacc6a5818c)!
 
+### Nix app
+
+
+Add this as a non-flake input, to use just the `default.nix`:
+
+```nix
+{
+  inputs = {
+    devour-flake.url = "github:srid/devour-flake/cat";
+    devour-flake.flake = false;
+  };
+}
+```
+
+Then, add an overlay entry to your nixpkgs:
+
+```nix
+{
+  devour-flake = self.callPackage inputs.devour-flake { inherit (inputs) devour-flake; };
+}
+```
+
+Use `pkgs.devour-flake` to get a convenient executable that will devour the given flake and spit out the out paths.
+
+
 ## Who uses it
 
 - In Jenkins CI ([jenkins-nix-ci](https://github.com/juspay/jenkins-nix-ci)), for building all flake outputs and pushing them to cachix: https://github.com/juspay/jenkins-nix-ci/commit/20a9f0ab337a14d0fdb23c1a526bae0d5b4e5536

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+
+# A convenient invoker for https://github.com/srid/devour-flake that then
+# outputs the built derivations to stdout.
+pkgs.writeShellApplication {
+  name = "devour-flake-cat";
+  runtimeInputs = [ pkgs.nix ];
+  text = ''
+    nix build github:srid/devour-flake/v1 \
+      -L --no-link --print-out-paths \
+      --override-input flake "$1" \
+      | xargs cat 
+  '';
+}

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@ pkgs.writeShellApplication {
   name = "devour-flake-cat";
   runtimeInputs = [ pkgs.nix ];
   text = ''
-    nix build ${devour-flake} \
+    nix build ${devour-flake}#default \
       -L --no-link --print-out-paths \
       --override-input flake "$1" \
       | xargs cat 

--- a/default.nix
+++ b/default.nix
@@ -3,7 +3,7 @@
 # A convenient invoker for https://github.com/srid/devour-flake that then
 # outputs the built derivations to stdout.
 pkgs.writeShellApplication {
-  name = "devour-flake-cat";
+  name = "devour-flake";
   runtimeInputs = [ pkgs.nix ];
   text = ''
     nix build ${devour-flake}#default \

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, devour-flake, ... }:
 
 # A convenient invoker for https://github.com/srid/devour-flake that then
 # outputs the built derivations to stdout.
@@ -6,7 +6,7 @@ pkgs.writeShellApplication {
   name = "devour-flake-cat";
   runtimeInputs = [ pkgs.nix ];
   text = ''
-    nix build github:srid/devour-flake/v1 \
+    nix build ${devour-flake} \
       -L --no-link --print-out-paths \
       --override-input flake "$1" \
       | xargs cat 


### PR DESCRIPTION
Not exposed in flake, due to null input changing drv hash. So must be used as non-flake input. See README for instructions.