### PR TITLE
Pass user arguments to `nix build` subcommand

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,8 @@ writeShellApplication {
     FLAKE="$1"
     shift 1 || true
 
-    nix "$@" build ${./.}#default \
+    nix build ${./.}#default \
+      "$@" \
       -L --no-link --print-out-paths \
       --override-input flake "$FLAKE" \
       | xargs cat 


### PR DESCRIPTION
Resolves #5 

Note that `--option` can be passed as an argument to the subcommand `build`.