### PR TITLE
Output in JSON format

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,18 +65,18 @@
                 then path.pname or path.name or null
                 else null;
             result = rec {
-              out-paths = lib.lists.flatten paths;
+              outPaths = lib.lists.flatten paths;
               # Indexed by the path's unique name
               # Paths without such a name will be ignored. Hence, you must rely on `out_paths` for comprehensive list of outputs.
-              by-name = lib.foldl' (acc: path:
+              byName = lib.foldl' (acc: path:
                 let name = nameForStorePath path;
                 in if name == null then acc else acc // { "${name}" = path; }
-              ) { } out-paths;
+              ) { } outPaths;
             };
           in
           rec {
             json = pkgs.writeText "devour-output.json" (builtins.toJSON result);
-            default = pkgs.writeText "devour-output" (lib.strings.concatLines result.out-paths);
+            default = pkgs.writeText "devour-output" (lib.strings.concatLines result.outPaths);
           };
       };
     };


### PR DESCRIPTION
Add a `.#json` package that contains the output in JSON format, allowing flexibility for the structure and content we want to return.