### PR TITLE
Remove `nixpkgs` input (follow from user flake instead)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,22 +18,6 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1693654884,
-        "narHash": "sha256-EqKKEl+IOS8TSjkt+xn1qGpsjnx5/ag33YNQ1+c7OuM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "e7f35e03abd06a2faef6684d0de813370e13bda8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
@@ -55,7 +39,6 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
         "systems": "systems"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,15 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     # The systems to build for. If empty, build for current system.
     systems.url = "github:srid/empty";
     flake = { };
   };
-  outputs = inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { self', pkgs, lib, system, ... }: {
+        _module.args.pkgs = import inputs.flake.inputs.nixpkgs { inherit system; };
         packages =
           let
             build-systems =


### PR DESCRIPTION
This means the user flake **must** have a nixpkgs input called `nixpkgs`. This may not be an unreasonable requirement, as it reduces the total number of flake inputs (one less nixpkgs to fetch and evaluate).